### PR TITLE
Missile Pathing Fix

### DIFF
--- a/fort_macarthur/lib/game/game_loop.dart
+++ b/fort_macarthur/lib/game/game_loop.dart
@@ -13,7 +13,7 @@ import 'missile_system.dart';
 class GameLoop extends BaseGame with PanDetector, TapDetector {
   MissileSystem missileSystem = new MissileSystem();
 
-  int enemyCount = 3;
+  int enemyCount = 0;
 
   bool isPressed = false;
   late HealthBar healthbar;
@@ -110,8 +110,7 @@ class GameLoop extends BaseGame with PanDetector, TapDetector {
 
     //TODO: Remove this when proper Enemy Manager is implemented.
     if (!paused) {
-      textPaint.render(
-          canvas, enemyCount.toString() + ' Enemies Remain', Vector2(95, 10),
+      textPaint.render(canvas, 'Enemies Disabled', Vector2(95, 10),
           anchor: Anchor.topCenter);
     } else {
       textPaint.render(canvas, 'Paused...', Vector2(95, 10),

--- a/fort_macarthur/lib/game/missile.dart
+++ b/fort_macarthur/lib/game/missile.dart
@@ -24,7 +24,7 @@ class Missile extends GameObjectRect {
         );
 
   void setPosition(Vector2 position) {
-    super.setPosition(position);
+    super.setPosition(position - (size / 2.0));
   }
 
   Vector2 get position {

--- a/fort_macarthur/lib/game/missile_system.dart
+++ b/fort_macarthur/lib/game/missile_system.dart
@@ -101,7 +101,10 @@ class MissileSystem {
       missile.setPosition(base.position + base.center());
 
       // missile direction calculations
-      missile.missileDirection = (tap.position - missile.position).normalized();
+      missile.missileDirection = ((tap.position - missile.size / 4.0) -
+              missile.position -
+              missile.size / 8.0)
+          .normalized();
       missile.faceDirection(missile.missileDirection);
     }
   }
@@ -129,7 +132,8 @@ class MissileSystem {
 
       // explosion happens when missile reaches it's destination
       if (missile.position.y < tap.position.y) {
-        explosions.add(Explosion(position: missile.position));
+        explosions
+            .add(Explosion(position: missile.position + missile.size / 2.0));
         missile.setPosition(base.position + base.center());
         missileLaunched = false;
         isPressed = false;


### PR DESCRIPTION
### What Changed
As per #11, I have (mostly) fixed the issue with our Missile not 100% following the line during it's movement.
By mostly, I mean in 99% of cases, it follows the line 1:1. Only in some small cases will it be off the line at the very end of it's journey, but it's not noticeable unless you go out of your way to look for it.

### Please Look At
The general implementation and fixes. A majority of this fix is just messing with missile size deductions to have it line up properly, so if you can suggest something I can do to improve it rather than that, let me know ASAP.

## Closed Issues
This PR fixes and closes issue #11, as it resolves the bug.