### PR TITLE
Level Selection

### DIFF
--- a/fort_macarthur/lib/Game/gamescreens/gameplay.dart
+++ b/fort_macarthur/lib/Game/gamescreens/gameplay.dart
@@ -14,7 +14,9 @@ GameLoop _missileGame = GameLoop();
 // This class represents the actual game screen
 // where all the action happens.
 class GamePlay extends StatelessWidget {
-  const GamePlay({Key? key}) : super(key: key);
+  final bool enteredFromGame;
+
+  const GamePlay({Key? key, required this.enteredFromGame}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
@@ -41,6 +43,7 @@ class GamePlay extends StatelessWidget {
             GameOverMenu.ID: (BuildContext context, GameLoop gameRef) =>
                 GameOverMenu(
                   gameRef: gameRef,
+                  enteredFromGame: enteredFromGame,
                 ),
           },
         ),

--- a/fort_macarthur/lib/Game/gamescreens/levelselect.dart
+++ b/fort_macarthur/lib/Game/gamescreens/levelselect.dart
@@ -43,6 +43,10 @@ class LevelSelect extends StatelessWidget {
                   }
                 },
                 child: levelOneComplete ? Text('Level One') : Text('LOCKED'),
+                style: levelOneComplete
+                    ? ElevatedButton.styleFrom()
+                    : ElevatedButton.styleFrom(
+                        primary: Colors.grey, onPrimary: Colors.white),
               ),
             ),
 
@@ -60,6 +64,10 @@ class LevelSelect extends StatelessWidget {
                   }
                 },
                 child: levelTwoComplete ? Text('Level Two') : Text('LOCKED'),
+                style: levelTwoComplete
+                    ? ElevatedButton.styleFrom()
+                    : ElevatedButton.styleFrom(
+                        primary: Colors.grey, onPrimary: Colors.white),
               ),
             ),
 
@@ -78,6 +86,10 @@ class LevelSelect extends StatelessWidget {
                 },
                 child:
                     levelThreeComplete ? Text('Level Three') : Text('LOCKED'),
+                style: levelThreeComplete
+                    ? ElevatedButton.styleFrom()
+                    : ElevatedButton.styleFrom(
+                        primary: Colors.grey, onPrimary: Colors.white),
               ),
             ),
 

--- a/fort_macarthur/lib/Game/gamescreens/levelselect.dart
+++ b/fort_macarthur/lib/Game/gamescreens/levelselect.dart
@@ -1,0 +1,103 @@
+import 'package:flutter/material.dart';
+import 'gameplay.dart';
+import 'mainmenu.dart';
+
+// Represents the main menu screen of Spacescape, allowing
+// players to start the game or modify in-game settings.
+class LevelSelect extends StatelessWidget {
+  const LevelSelect({Key? key}) : super(key: key);
+  final bool levelOneComplete = true;
+  final bool levelTwoComplete = false;
+  final bool levelThreeComplete = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            // Game title.
+            Padding(
+              padding: const EdgeInsets.symmetric(vertical: 50.0),
+              child: Text(
+                'Pick a Level',
+                style: TextStyle(
+                  fontSize: 50.0,
+                  color: Colors.black,
+                ),
+              ),
+            ),
+
+            // Level One
+            SizedBox(
+              width: MediaQuery.of(context).size.width / 3,
+              child: ElevatedButton(
+                onPressed: () {
+                  if (levelOneComplete) {
+                    Navigator.of(context).pushReplacement(
+                      MaterialPageRoute(
+                        builder: (context) => const GamePlay(),
+                      ),
+                    );
+                  }
+                },
+                child: levelOneComplete ? Text('Level One') : Text('LOCKED'),
+              ),
+            ),
+
+            // Level Two
+            SizedBox(
+              width: MediaQuery.of(context).size.width / 3,
+              child: ElevatedButton(
+                onPressed: () {
+                  if (levelTwoComplete) {
+                    Navigator.of(context).pushReplacement(
+                      MaterialPageRoute(
+                        builder: (context) => const GamePlay(),
+                      ),
+                    );
+                  }
+                },
+                child: levelTwoComplete ? Text('Level Two') : Text('LOCKED'),
+              ),
+            ),
+
+            // Level Three
+            SizedBox(
+              width: MediaQuery.of(context).size.width / 3,
+              child: ElevatedButton(
+                onPressed: () {
+                  if (levelThreeComplete) {
+                    Navigator.of(context).pushReplacement(
+                      MaterialPageRoute(
+                        builder: (context) => const GamePlay(),
+                      ),
+                    );
+                  }
+                },
+                child:
+                    levelThreeComplete ? Text('Level Three') : Text('LOCKED'),
+              ),
+            ),
+
+            // Exit button.
+            SizedBox(
+              width: MediaQuery.of(context).size.width / 3,
+              child: ElevatedButton(
+                onPressed: () {
+                  Navigator.of(context).pushReplacement(
+                    MaterialPageRoute(
+                      builder: (context) => const MainMenu(),
+                    ),
+                  );
+                },
+                child: Text('Go Back'),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/fort_macarthur/lib/Game/gamescreens/levelselect.dart
+++ b/fort_macarthur/lib/Game/gamescreens/levelselect.dart
@@ -37,7 +37,8 @@ class LevelSelect extends StatelessWidget {
                   if (levelOneComplete) {
                     Navigator.of(context).pushReplacement(
                       MaterialPageRoute(
-                        builder: (context) => const GamePlay(),
+                        builder: (context) =>
+                            const GamePlay(enteredFromGame: false),
                       ),
                     );
                   }
@@ -58,7 +59,8 @@ class LevelSelect extends StatelessWidget {
                   if (levelTwoComplete) {
                     Navigator.of(context).pushReplacement(
                       MaterialPageRoute(
-                        builder: (context) => const GamePlay(),
+                        builder: (context) =>
+                            const GamePlay(enteredFromGame: false),
                       ),
                     );
                   }
@@ -79,7 +81,8 @@ class LevelSelect extends StatelessWidget {
                   if (levelThreeComplete) {
                     Navigator.of(context).pushReplacement(
                       MaterialPageRoute(
-                        builder: (context) => const GamePlay(),
+                        builder: (context) =>
+                            const GamePlay(enteredFromGame: false),
                       ),
                     );
                   }

--- a/fort_macarthur/lib/Game/gamescreens/mainmenu.dart
+++ b/fort_macarthur/lib/Game/gamescreens/mainmenu.dart
@@ -3,6 +3,7 @@ import 'package:flutter/services.dart';
 
 import 'gameplay.dart';
 import 'options.dart';
+import 'levelselect.dart';
 
 // Represents the main menu screen of Spacescape, allowing
 // players to start the game or modify in-game settings.
@@ -42,6 +43,23 @@ class MainMenu extends StatelessWidget {
                   );
                 },
                 child: Text('Play'),
+              ),
+            ),
+
+            // Level Select button.
+            SizedBox(
+              width: MediaQuery.of(context).size.width / 3,
+              child: ElevatedButton(
+                onPressed: () {
+                  // Push and replace current screen (i.e MainMenu) with
+                  // SelectSpaceship(), so that player can select a spaceship.
+                  Navigator.of(context).pushReplacement(
+                    MaterialPageRoute(
+                      builder: (context) => const LevelSelect(),
+                    ),
+                  );
+                },
+                child: Text('Level Select'),
               ),
             ),
 

--- a/fort_macarthur/lib/Game/gamescreens/mainmenu.dart
+++ b/fort_macarthur/lib/Game/gamescreens/mainmenu.dart
@@ -38,7 +38,8 @@ class MainMenu extends StatelessWidget {
                   // SelectSpaceship(), so that player can select a spaceship.
                   Navigator.of(context).pushReplacement(
                     MaterialPageRoute(
-                      builder: (context) => const GamePlay(),
+                      builder: (context) =>
+                          const GamePlay(enteredFromGame: true),
                     ),
                   );
                 },

--- a/fort_macarthur/lib/Game/overlays/game_over_menu.dart
+++ b/fort_macarthur/lib/Game/overlays/game_over_menu.dart
@@ -1,13 +1,17 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:fort_macarthur/Game/GameScreens/levelselect.dart';
 import 'package:fort_macarthur/Game/gamescreens/mainmenu.dart';
 import '../game/game_loop.dart';
 
 class GameOverMenu extends StatelessWidget {
   static const String ID = 'GameOver';
   final GameLoop gameRef;
+  final bool enteredFromGame;
 
-  const GameOverMenu({Key? key, required this.gameRef}) : super(key: key);
+  const GameOverMenu(
+      {Key? key, required this.gameRef, required this.enteredFromGame})
+      : super(key: key);
 
   @override
   Widget build(BuildContext context) {
@@ -35,23 +39,41 @@ class GameOverMenu extends StatelessWidget {
                 children: [
                   Column(
                     children: [
-                      ElevatedButton(
-                        child: Text(
-                          'Main Menu',
-                          style: TextStyle(fontSize: 10.0),
-                        ),
-                        onPressed: () {
-                          gameRef.reset();
-                          gameRef.overlays.remove(GameOverMenu.ID);
-                          // Push and replace current screen (i.e MainMenu) with
-                          // SelectSpaceship(), so that player can select a spaceship.
-                          Navigator.of(context).pushReplacement(
-                            MaterialPageRoute(
-                              builder: (context) => const MainMenu(),
+                      enteredFromGame
+                          ? ElevatedButton(
+                              child: Text(
+                                'Main Menu',
+                                style: TextStyle(fontSize: 10.0),
+                              ),
+                              onPressed: () {
+                                gameRef.reset();
+                                gameRef.overlays.remove(GameOverMenu.ID);
+                                // Push and replace current screen (i.e MainMenu) with
+                                // SelectSpaceship(), so that player can select a spaceship.
+                                Navigator.of(context).pushReplacement(
+                                  MaterialPageRoute(
+                                    builder: (context) => const MainMenu(),
+                                  ),
+                                );
+                              },
+                            )
+                          : ElevatedButton(
+                              child: Text(
+                                'Level Select',
+                                style: TextStyle(fontSize: 10.0),
+                              ),
+                              onPressed: () {
+                                gameRef.reset();
+                                gameRef.overlays.remove(GameOverMenu.ID);
+                                // Push and replace current screen (i.e MainMenu) with
+                                // SelectSpaceship(), so that player can select a spaceship.
+                                Navigator.of(context).pushReplacement(
+                                  MaterialPageRoute(
+                                    builder: (context) => const LevelSelect(),
+                                  ),
+                                );
+                              },
                             ),
-                          );
-                        },
-                      ),
                       ElevatedButton(
                         child: Text(
                           'Close Game',


### PR DESCRIPTION
### What Changed
A Level Select option has been added to the Main Menu.
The GamePlay screen now takes in a bool to determine if the Game was entered from the Main Menu's Play button, or one of the Level Select options. Using this, the Player can go back to the Level Select screen after playing a Level.
Currently, there are three buttons for three Levels. Functionally, they are identical. They will be used later on once we have the ability to define different Game Elements for each Level to help the app determine what variables and unlocks to apply for each Level.

### Please Look At
The Level Select Screen. Change the booleans at the top of levelselect.dart and confirm that they become locked/unlocked when true/false. Confirm that clicking Locked buttons does nothing. Please also try to lose a game when entering the Level Select and confirm that the option to return to the Level Select screen appears on the Game Over screen.

### Closed Issues
This Pull Request closes issue #25.

### NOTES
As mentioned in What Changed, the three buttons for the three Levels are functionally identical. They will be used later on once we have the ability to define different Game Elements for each Level to help the app determine what variables and unlocks to apply for each Level. Please keep this in mind while doing the Pull Request.