### PR TITLE
Upgrades

### DIFF
--- a/fort_macarthur/lib/Game/game/game_loop.dart
+++ b/fort_macarthur/lib/Game/game/game_loop.dart
@@ -8,6 +8,7 @@ import 'package:flame/components.dart'; // Needed for Anchor class
 import '../models/healthbar.dart';
 import '../models/enemyplane.dart';
 import '../models/missile_system.dart';
+import '../models/upgrades.dart';
 
 // main game loop. pan detector necessary for touch detection
 class GameLoop extends BaseGame with PanDetector, TapDetector {
@@ -39,6 +40,12 @@ class GameLoop extends BaseGame with PanDetector, TapDetector {
         add(EnemyPlane(size, healthbar));
       }
       missileSystem.baseInit(size);
+
+      ammoManager.ammo += finalTallyAmmo;
+      healthbar.upgradeHealth(finalTallyHealth);
+
+      print(finalTallyAmmo);
+      print(finalTallyHealth);
     }
   }
 

--- a/fort_macarthur/lib/Game/game/game_loop.dart
+++ b/fort_macarthur/lib/Game/game/game_loop.dart
@@ -100,10 +100,17 @@ class GameLoop extends BaseGame with PanDetector, TapDetector {
   // updates game
   void update(double dt) {
     super.update(dt);
+
+    if (missileSystem.wasLaunched) {
+      ammoManager.decreaseAmmo(1);
+      missileSystem.wasLaunched = false;
+    }
+
     missileSystem.update(dt);
     healthbar.update(dt);
 
-    if (healthbar.getHealth() == 0 || ammoManager.ammo == 0) {
+    if (healthbar.getHealth() == 0 ||
+        (ammoManager.ammo == 0 && !missileSystem.missileLaunched)) {
       overlays.add(GameOverMenu.ID);
     }
   }

--- a/fort_macarthur/lib/Game/game/game_loop.dart
+++ b/fort_macarthur/lib/Game/game/game_loop.dart
@@ -43,9 +43,6 @@ class GameLoop extends BaseGame with PanDetector, TapDetector {
 
       ammoManager.ammo += finalTallyAmmo;
       healthbar.upgradeHealth(finalTallyHealth);
-
-      print(finalTallyAmmo);
-      print(finalTallyHealth);
     }
   }
 
@@ -72,16 +69,22 @@ class GameLoop extends BaseGame with PanDetector, TapDetector {
 
   // drag motion started
   void onPanStart(DragStartInfo details) {
+    isPressed = true;
+    healthbar.setFade(isPressed);
     missileSystem.setupDestination(details);
   }
 
   // continued touch dragging movement
   void onPanUpdate(DragUpdateInfo details) {
+    isPressed = true;
+    healthbar.setFade(isPressed);
     missileSystem.moveDestination(details);
   }
 
   // when the touch ends
   void onPanEnd(DragEndInfo details) {
+    isPressed = false;
+    healthbar.setFade(isPressed);
     missileSystem.launchMissile();
   }
 

--- a/fort_macarthur/lib/Game/gamescreens/levelselect.dart
+++ b/fort_macarthur/lib/Game/gamescreens/levelselect.dart
@@ -1,14 +1,15 @@
 import 'package:flutter/material.dart';
 import 'gameplay.dart';
 import 'mainmenu.dart';
+import '../models/upgrades.dart';
 
 // Represents the main menu screen of Spacescape, allowing
 // players to start the game or modify in-game settings.
 class LevelSelect extends StatelessWidget {
   const LevelSelect({Key? key}) : super(key: key);
   final bool levelOneComplete = true;
-  final bool levelTwoComplete = false;
-  final bool levelThreeComplete = false;
+  final bool levelTwoComplete = true;
+  final bool levelThreeComplete = true;
 
   @override
   Widget build(BuildContext context) {
@@ -57,6 +58,7 @@ class LevelSelect extends StatelessWidget {
               child: ElevatedButton(
                 onPressed: () {
                   if (levelTwoComplete) {
+                    pickedLevelTwo(); // update upgrades.dart globals
                     Navigator.of(context).pushReplacement(
                       MaterialPageRoute(
                         builder: (context) =>
@@ -79,6 +81,7 @@ class LevelSelect extends StatelessWidget {
               child: ElevatedButton(
                 onPressed: () {
                   if (levelThreeComplete) {
+                    pickedLevelThree(); // update upgrades.dart globals
                     Navigator.of(context).pushReplacement(
                       MaterialPageRoute(
                         builder: (context) =>

--- a/fort_macarthur/lib/Game/models/ammo.dart
+++ b/fort_macarthur/lib/Game/models/ammo.dart
@@ -20,7 +20,7 @@ class AmmunitionManager {
 
   void onTapDown(TapDownInfo event) {
     //print("Player tap down on ${event.eventPosition.game}");
-    decreaseAmmo(1);
+    //decreaseAmmo(1);
     //fulfilledincreaseAmmo(1);
   }
 

--- a/fort_macarthur/lib/Game/models/healthbar.dart
+++ b/fort_macarthur/lib/Game/models/healthbar.dart
@@ -5,7 +5,8 @@ import 'package:flutter/material.dart';
 class HealthBar extends PositionComponent {
   static const int MAX_OPAQUE = 255;
 
-  static const maxHealth = 10.0;
+  static const defaultMaxHealth = 10.0;
+  static double maxHealth = defaultMaxHealth;
   static const int fadeRate = 10;
   static double health = 10.0;
   static int currentFade = 255;
@@ -54,6 +55,13 @@ class HealthBar extends PositionComponent {
 
   void setFade(bool isFading) {
     fade = isFading;
+  }
+
+  void upgradeHealth(int amount) {
+    health += amount;
+    maxHealth = defaultMaxHealth + amount;
+
+    if (health > maxHealth) health = maxHealth;
   }
 
   /// Adjust Health based on amount passed in.

--- a/fort_macarthur/lib/Game/models/missile_system.dart
+++ b/fort_macarthur/lib/Game/models/missile_system.dart
@@ -31,6 +31,7 @@ class MissileSystem {
   bool explosionTriggered = false;
   bool explosionVisible = false;
   bool isPressed = false;
+  bool wasLaunched = false;
 
   Paint whiteBox = new Paint()..color = Color(0xFFFFFFFF);
 
@@ -124,6 +125,7 @@ class MissileSystem {
     // checks if missile destination is not under the base
     if (isPressed && !missileLaunched && tap.position.y < base.position.y) {
       missileLaunched = true;
+      wasLaunched = true;
       isPressed = true;
     } else {
       isPressed = false;

--- a/fort_macarthur/lib/Game/models/upgrades.dart
+++ b/fort_macarthur/lib/Game/models/upgrades.dart
@@ -1,0 +1,13 @@
+// Level one inherently has no upgrades set, so there will be no function for it
+
+int finalTallyAmmo = 0;
+int finalTallyHealth = 0;
+
+void pickedLevelTwo() {
+  finalTallyAmmo = 5;
+}
+
+void pickedLevelThree() {
+  finalTallyAmmo = 5;
+  finalTallyHealth = 2;
+}

--- a/fort_macarthur/lib/Game/models/upgrades.dart
+++ b/fort_macarthur/lib/Game/models/upgrades.dart
@@ -5,6 +5,7 @@ int finalTallyHealth = 0;
 
 void pickedLevelTwo() {
   finalTallyAmmo = 5;
+  finalTallyHealth = 0;
 }
 
 void pickedLevelThree() {


### PR DESCRIPTION
### What Changed
Each Level now sets global Upgrade variables, which are added to the Ammo / Health Managers.
These variables act as the Upgrade system, giving the Player more Health or Ammo depending on the Level they chose to play on.
This allows each variable to be pre-set when choosing a Level to replay through the Level Select feature.

### Please Look At
The general implementation of global variables in order to control Upgrades.
Please try out the implementation too using the Level Select.
Level Two should give 5 more ammo, and Level Three should give 5 more ammo and 2 more Health (1 more hit before losing).

### Issues Closed
This Pull Request closes #27.